### PR TITLE
fix: download the browser in advance

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import {
 import { mdToPdf } from "./md-to-pdf.ts";
 import { getFilename } from "./utils/filename.ts";
 import type { MdToPdfOptions } from "./types.ts";
+import { getBinary } from "@astral/astral";
 
 function printHelp(): void {
   const help = `md2pdf: ${
@@ -88,6 +89,10 @@ if (args._) {
     }
   }
 }
+
+// Prepare browser
+// If the browser is not installed, download it
+await getBinary("chrome");
 
 if (paths.length < 1) {
   const exitCode = args._.length ? 1 : 0;


### PR DESCRIPTION
Console display issues occur if we do not download the browser first.