### PR TITLE
chore: use playwright-core instead of astral

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A simple CLI tool for converting markdown to PDF.
 
 ## Installation
 
+To run it, you need to have [Google Chrome](https://www.google.com/chrome/) installed separately from the CLI.
+
 ```sh
 deno install -grA jsr:@ryu/md2pdf/cli
 ```

--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,7 @@
     "dev:watch": "deno run --A ./src/cli.ts --watch -- README.md"
   },
   "imports": {
-    "@astral/astral": "jsr:@astral/astral@^0.5.2",
+    "playwright-core": "npm:playwright-core@^1.55.0",
     "@std/assert": "jsr:@std/assert@^1.0.13",
     "@std/cli": "jsr:@std/cli@1.0.17",
     "@std/fmt": "jsr:@std/fmt@^1.0.7",
@@ -26,6 +26,9 @@
     "md4w": "npm:md4w@^0.2.6",
     "node-html-parser": "npm:node-html-parser@^7.0.1",
     "shiki": "npm:shiki@^3.3.0"
+  },
+  "fmt": {
+    "proseWrap": "preserve"
   },
   "exclude": [".gitattributes", ".github", "src/testdata", "**/*/*_test.ts"]
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,66 +1,37 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@astral/astral@~0.5.2": "0.5.2",
-    "jsr:@deno-library/progress@^1.5.1": "1.5.1",
-    "jsr:@std/assert@^1.0.13": "1.0.13",
-    "jsr:@std/async@1": "1.0.12",
+    "jsr:@std/assert@^1.0.13": "1.0.14",
     "jsr:@std/cli@1.0.17": "1.0.17",
-    "jsr:@std/collections@^1.0.10": "1.0.10",
-    "jsr:@std/fmt@1.0.3": "1.0.3",
-    "jsr:@std/fmt@^1.0.7": "1.0.7",
+    "jsr:@std/collections@^1.1.1": "1.1.1",
+    "jsr:@std/fmt@^1.0.7": "1.0.8",
     "jsr:@std/front-matter@^1.0.9": "1.0.9",
-    "jsr:@std/fs@1": "1.0.16",
-    "jsr:@std/internal@^1.0.6": "1.0.6",
-    "jsr:@std/io@0.225.0": "0.225.0",
-    "jsr:@std/path@1": "1.0.9",
-    "jsr:@std/path@^1.0.9": "1.0.9",
-    "jsr:@std/toml@^1.0.3": "1.0.4",
-    "jsr:@std/yaml@^1.0.5": "1.0.6",
-    "jsr:@std/yaml@^1.0.6": "1.0.6",
-    "jsr:@zip-js/zip-js@^2.7.52": "2.7.60",
-    "npm:md4w@~0.2.6": "0.2.6",
+    "jsr:@std/internal@^1.0.10": "1.0.10",
+    "jsr:@std/internal@^1.0.9": "1.0.10",
+    "jsr:@std/path@^1.0.9": "1.1.1",
+    "jsr:@std/toml@^1.0.3": "1.0.8",
+    "jsr:@std/yaml@^1.0.5": "1.0.8",
+    "jsr:@std/yaml@^1.0.6": "1.0.8",
+    "npm:md4w@~0.2.6": "0.2.7",
     "npm:node-html-parser@^7.0.1": "7.0.1",
-    "npm:shiki@^3.3.0": "3.3.0"
+    "npm:playwright-core@^1.55.0": "1.55.0",
+    "npm:shiki@^3.3.0": "3.12.1"
   },
   "jsr": {
-    "@astral/astral@0.5.2": {
-      "integrity": "dc4b7e0ea5d8186fcd9e33e2c54e62913d7eb99d5a2d4f987b1c5399d8e295de",
+    "@std/assert@1.0.14": {
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
       "dependencies": [
-        "jsr:@deno-library/progress",
-        "jsr:@std/async",
-        "jsr:@std/fs",
-        "jsr:@std/path@1",
-        "jsr:@zip-js/zip-js"
+        "jsr:@std/internal@^1.0.10"
       ]
-    },
-    "@deno-library/progress@1.5.1": {
-      "integrity": "966611826b8bb27baae73ab1c4fa4317cd4edd2abb99750cd6f8488d22d5b121",
-      "dependencies": [
-        "jsr:@std/fmt@1.0.3",
-        "jsr:@std/io"
-      ]
-    },
-    "@std/assert@1.0.13": {
-      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
-      "dependencies": [
-        "jsr:@std/internal"
-      ]
-    },
-    "@std/async@1.0.12": {
-      "integrity": "d1bfcec459e8012846fe4e38dfc4241ab23240ecda3d8d6dfcf6d81a632e803d"
     },
     "@std/cli@1.0.17": {
       "integrity": "e15b9abe629e17be90cc6216327f03a29eae613365f1353837fa749aad29ce7b"
     },
-    "@std/collections@1.0.10": {
-      "integrity": "903af106a3d92970d74e20f7ebff77d9658af9bef4403f1dc42a7801c0575899"
+    "@std/collections@1.1.1": {
+      "integrity": "eff6443fbd9d5a6697018fb39c5d13d5f662f0045f21392d640693d0008ab2af"
     },
-    "@std/fmt@1.0.3": {
-      "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
-    },
-    "@std/fmt@1.0.7": {
-      "integrity": "2a727c043d8df62cd0b819b3fb709b64dd622e42c3b1bb817ea7e6cc606360fb"
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
     },
     "@std/front-matter@1.0.9": {
       "integrity": "ee6201d06674cbef137dda2252f62477450b48249e7d8d9ab57a30f85ff6f051",
@@ -69,34 +40,28 @@
         "jsr:@std/yaml@^1.0.5"
       ]
     },
-    "@std/fs@1.0.16": {
-      "integrity": "81878f62b6eeda0bf546197fc3daa5327c132fee1273f6113f940784a468b036"
+    "@std/internal@1.0.10": {
+      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
     },
-    "@std/internal@1.0.6": {
-      "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
+    "@std/path@1.1.1": {
+      "integrity": "fe00026bd3a7e6a27f73709b83c607798be40e20c81dde655ce34052fd82ec76",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.9"
+      ]
     },
-    "@std/io@0.225.0": {
-      "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
-    },
-    "@std/path@1.0.9": {
-      "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"
-    },
-    "@std/toml@1.0.4": {
-      "integrity": "8781e687d04c8fbe246b9c5714be01925792a94d943462c33777675ab557cff1",
+    "@std/toml@1.0.8": {
+      "integrity": "eb8ae76b4cc1c6c13f2a91123675823adbec2380de75cd3748c628960d952164",
       "dependencies": [
         "jsr:@std/collections"
       ]
     },
-    "@std/yaml@1.0.6": {
-      "integrity": "c9a5a914e1d51c46756cb10e356710035cfa905e713c90d3b711413fd3aead27"
-    },
-    "@zip-js/zip-js@2.7.60": {
-      "integrity": "6bb6cf0d02b64ca9acba8c7bc072293609ec3bad584db2b5cf3bb089e031ea0e"
+    "@std/yaml@1.0.8": {
+      "integrity": "90b8aab62995e929fa0ea5f4151c287275b63e321ac375c35ff7406ca60c169d"
     }
   },
   "npm": {
-    "@shikijs/core@3.3.0": {
-      "integrity": "sha512-CovkFL2WVaHk6PCrwv6ctlmD4SS1qtIfN8yEyDXDYWh4ONvomdM9MaFw20qHuqJOcb8/xrkqoWQRJ//X10phOQ==",
+    "@shikijs/core@3.12.1": {
+      "integrity": "sha512-j9+UDQ6M50xvaSR/e9lg212H0Fqxy3lYd39Q6YITYQxfrb5VYNUKPLZp4PN9f+YmRcdpyNAm3obn/tIZ2WkUWg==",
       "dependencies": [
         "@shikijs/types",
         "@shikijs/vscode-textmate",
@@ -104,35 +69,35 @@
         "hast-util-to-html"
       ]
     },
-    "@shikijs/engine-javascript@3.3.0": {
-      "integrity": "sha512-XlhnFGv0glq7pfsoN0KyBCz9FJU678LZdQ2LqlIdAj6JKsg5xpYKay3DkazXWExp3DTJJK9rMOuGzU2911pg7Q==",
+    "@shikijs/engine-javascript@3.12.1": {
+      "integrity": "sha512-mwif5T3rEBSMn/1m9dNi4WmB4dxH4VfYqreQMLpbFYov8MM3Gus98I549amFMjtEmYDAkTKGP7bmsv1n9t9I+A==",
       "dependencies": [
         "@shikijs/types",
         "@shikijs/vscode-textmate",
         "oniguruma-to-es"
       ]
     },
-    "@shikijs/engine-oniguruma@3.3.0": {
-      "integrity": "sha512-l0vIw+GxeNU7uGnsu6B+Crpeqf+WTQ2Va71cHb5ZYWEVEPdfYwY5kXwYqRJwHrxz9WH+pjSpXQz+TJgAsrkA5A==",
+    "@shikijs/engine-oniguruma@3.12.1": {
+      "integrity": "sha512-hbYq+XOc55CU7Irkhsgwh8WgQbx2W5IVzHV4l+wZ874olMLSNg5o3F73vo9m4SAhimFyqq/86xnx9h+T30HhhQ==",
       "dependencies": [
         "@shikijs/types",
         "@shikijs/vscode-textmate"
       ]
     },
-    "@shikijs/langs@3.3.0": {
-      "integrity": "sha512-zt6Kf/7XpBQKSI9eqku+arLkAcDQ3NHJO6zFjiChI8w0Oz6Jjjay7pToottjQGjSDCFk++R85643WbyINcuL+g==",
+    "@shikijs/langs@3.12.1": {
+      "integrity": "sha512-Y1MbMfVO5baRz7Boo7EoD36TmzfUx/I5n8e+wZumx6SlUA81Zj1ZwNJL871iIuSHrdsheV4AxJtHQ9mlooklmg==",
       "dependencies": [
         "@shikijs/types"
       ]
     },
-    "@shikijs/themes@3.3.0": {
-      "integrity": "sha512-tXeCvLXBnqq34B0YZUEaAD1lD4lmN6TOHAhnHacj4Owh7Ptb/rf5XCDeROZt2rEOk5yuka3OOW2zLqClV7/SOg==",
+    "@shikijs/themes@3.12.1": {
+      "integrity": "sha512-9JrAm9cA5hqM/YXymA3oAAZdnCgQf1zyrNDtsnM105nNEoEpux4dyzdoOjc2KawEKj1iUs/WH2ota6Atp7GYkQ==",
       "dependencies": [
         "@shikijs/types"
       ]
     },
-    "@shikijs/types@3.3.0": {
-      "integrity": "sha512-KPCGnHG6k06QG/2pnYGbFtFvpVJmC3uIpXrAiPrawETifujPBv0Se2oUxm5qYgjCvGJS9InKvjytOdN+bGuX+Q==",
+    "@shikijs/types@3.12.1": {
+      "integrity": "sha512-Is/p+1vTss22LIsGCJTmGrxu7ZC1iBL9doJFYLaZ4aI8d0VDXb7Mn0kBzhkc7pdsRpmUbQLQ5HXwNpa3H6F8og==",
       "dependencies": [
         "@shikijs/vscode-textmate",
         "@types/hast"
@@ -174,8 +139,8 @@
     "comma-separated-tokens@2.0.3": {
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
-    "css-select@5.1.0": {
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+    "css-select@5.2.2": {
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "dependencies": [
         "boolbase",
         "css-what",
@@ -184,8 +149,8 @@
         "nth-check"
       ]
     },
-    "css-what@6.1.0": {
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    "css-what@6.2.2": {
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="
     },
     "dequal@2.0.3": {
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
@@ -221,9 +186,6 @@
         "domhandler"
       ]
     },
-    "emoji-regex-xs@1.0.0": {
-      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="
-    },
     "entities@4.5.0": {
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
@@ -250,13 +212,14 @@
       ]
     },
     "he@1.2.0": {
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": true
     },
     "html-void-elements@3.0.0": {
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="
     },
-    "md4w@0.2.6": {
-      "integrity": "sha512-CBLQ2PxVe9WA+/nndZCx/Y+1C3DtmtSeubmXTPhMIgsXtq9gVGleikREko5FYnV6Dz4cHDWm0Ea+YMLpIjP4Kw=="
+    "md4w@0.2.7": {
+      "integrity": "sha512-lFM7vwk3d4MzkV2mija7aPkK6OjKXZDQsH2beX+e2cvccBoqc6RraheMtAO0Wcr/gjj5L+WS5zhb+06AmuGZrg=="
     },
     "mdast-util-to-hast@13.2.0": {
       "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
@@ -309,20 +272,23 @@
         "boolbase"
       ]
     },
-    "oniguruma-parser@0.11.2": {
-      "integrity": "sha512-F7Ld4oDZJCI5/wCZ8AOffQbqjSzIRpKH7I/iuSs1SkhZeCj0wS6PMZ4W6VA16TWHrAo0Y9bBKEJOe7tvwcTXnw=="
+    "oniguruma-parser@0.12.1": {
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="
     },
-    "oniguruma-to-es@4.2.0": {
-      "integrity": "sha512-MDPs6KSOLS0tKQ7joqg44dRIRZUyotfTy0r+7oEEs6VwWWP0+E2PPDYWMFN0aqOjRyWHBYq7RfKw9GQk2S2z5g==",
+    "oniguruma-to-es@4.3.3": {
+      "integrity": "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==",
       "dependencies": [
-        "emoji-regex-xs",
         "oniguruma-parser",
         "regex",
         "regex-recursion"
       ]
     },
-    "property-information@7.0.0": {
-      "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg=="
+    "playwright-core@1.55.0": {
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "bin": true
+    },
+    "property-information@7.1.0": {
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="
     },
     "regex-recursion@6.0.2": {
       "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
@@ -339,8 +305,8 @@
         "regex-utilities"
       ]
     },
-    "shiki@3.3.0": {
-      "integrity": "sha512-j0Z1tG5vlOFGW8JVj0Cpuatzvshes7VJy5ncDmmMaYcmnGW0Js1N81TOW98ivTFNZfKRn9uwEg/aIm638o368g==",
+    "shiki@3.12.1": {
+      "integrity": "sha512-eMlxVaXyuNQAQCaMtDKQjKv0eVm+kA6fsZtv9UqKgspP+7lWCVi7SoN+cJq1dawvIDQY7TI3SixamztotM6R6Q==",
       "dependencies": [
         "@shikijs/core",
         "@shikijs/engine-javascript",
@@ -398,8 +364,8 @@
         "unist-util-visit-parents"
       ]
     },
-    "vfile-message@4.0.2": {
-      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+    "vfile-message@4.0.3": {
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
       "dependencies": [
         "@types/unist",
         "unist-util-stringify-position"
@@ -418,7 +384,6 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@astral/astral@~0.5.2",
       "jsr:@std/assert@^1.0.13",
       "jsr:@std/cli@1.0.17",
       "jsr:@std/fmt@^1.0.7",
@@ -427,6 +392,7 @@
       "jsr:@std/yaml@^1.0.6",
       "npm:md4w@~0.2.6",
       "npm:node-html-parser@^7.0.1",
+      "npm:playwright-core@^1.55.0",
       "npm:shiki@^3.3.0"
     ]
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,6 @@ import {
 import { mdToPdf } from "./md-to-pdf.ts";
 import { getFilename } from "./utils/filename.ts";
 import type { MdToPdfOptions } from "./types.ts";
-import { getBinary } from "@astral/astral";
 
 function printHelp(): void {
   const help = `md2pdf: ${
@@ -89,10 +88,6 @@ if (args._) {
     }
   }
 }
-
-// Prepare browser
-// If the browser is not installed, download it
-await getBinary("chrome");
 
 if (paths.length < 1) {
   const exitCode = args._.length ? 1 : 0;

--- a/src/md-to-pdf.ts
+++ b/src/md-to-pdf.ts
@@ -1,4 +1,4 @@
-import { launch } from "@astral/astral";
+import * as playwright from "playwright-core";
 import { launchHttpServer } from "./utils/server.ts";
 import type { MdToPdfOptions } from "./types.ts";
 
@@ -19,10 +19,12 @@ export async function mdToPdf(
 ): Promise<Uint8Array> {
   const server = launchHttpServer(path, options);
 
-  const browser = await launch();
-  const page = await browser.newPage(`http://localhost:${server.addr.port}`);
-  const pdf = await page.pdf({ printBackground: true });
+  const browser = await playwright.chromium.launch({ channel: "chrome" });
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${server.addr.port}`);
+  await page.waitForLoadState("domcontentloaded");
 
+  const pdf = await page.pdf({ printBackground: true });
   // Close the browser and the server
   await browser.close();
   await server.shutdown();

--- a/src/utils/markdown.css
+++ b/src/utils/markdown.css
@@ -8,12 +8,8 @@ html {
 
 body {
   font-family:
-    "Helvetica Neue",
-    Arial,
-    "Hiragino Kaku Gothic ProN",
-    "Hiragino Sans",
-    Meiryo,
-    sans-serif;
+    "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans",
+    Meiryo, sans-serif;
 }
 
 pre {


### PR DESCRIPTION
With Deno's improved Node.js compatibility, Playwright runs without issue, so we're considering migrating.